### PR TITLE
move initialize()

### DIFF
--- a/DAC8562.cpp
+++ b/DAC8562.cpp
@@ -32,10 +32,13 @@ void DAC8562::begin()
   SPI.begin();
   SPI.setDataMode(SPI_MODE1);
   SPI.setBitOrder(MSBFIRST);
-  initialize();
+  
   /* !Chip select (low to enable) */
   pinMode(_cs_pin, OUTPUT);
   digitalWrite(_cs_pin,  1);
+  
+  /* Initialize DAC8592 */
+  initialize();
 };
 
 


### PR DESCRIPTION
The `initialize()` routine start writing data through the SPI interface, and therefore using the slave select signal, before the slave select pin (`_cs_pin`) has been configured. Surprisingly, this works without problems on Arduino Uno and a classic Nano (and probably other boards with ATmega328), but not with the Nano Every (and probably other ATMega4809-based boards). Initializing the DAC _after_ configuring the pin resolves the issue. 